### PR TITLE
add ContextMeta(s) protos

### DIFF
--- a/prefab.proto
+++ b/prefab.proto
@@ -275,6 +275,14 @@ message IdBlockRequest {
   int64 size = 4;
 }
 
+message ContextMeta {
+  string name = 1;
+  map<string, int32> field_types = 2;
+}
+
+message ContextMetas {
+  repeated ContextMeta metas = 1;
+}
 
 
 


### PR DESCRIPTION
These protos will be used for clients to report the names and types of the fields being used in applications so we can power auto-complete/discovery in the config rules UI