### PR TITLE
Add protos for telemetry data stream

### DIFF
--- a/prefab.proto
+++ b/prefab.proto
@@ -302,3 +302,34 @@ message EvaluatedConfig {
 message EvaluatedConfigs {
   repeated EvaluatedConfig configs = 1;
 }
+
+message ConfigEvaluationCounter {
+  int64 count = 1;
+  int64 config_id = 2;
+  optional uint32 selected_index = 3; // index into the allowed-values list in the config
+  ConfigValue selected_value = 4;
+  optional uint32 weighted_value_index = 5; // index into the weighted value array
+}
+
+message ConfigEvaluationSummary {
+  string key = 1;
+  ConfigType type = 2; // type of config eval
+  repeated ConfigEvaluationCounter counters = 3;
+}
+
+message ConfigEvaluationSummaries {
+  int64 start = 1;
+  int64 end = 2;
+  repeated ConfigEvaluationSummaries summaries = 3;
+}
+
+message TelemetryEvent {
+  oneof payload {
+    string ConfigEvaluationSummaries = 2;
+  }
+}
+
+message TelemetryEvents {
+  string instance_hash = 1; // random UUID generated on startup - represents the server so we can aggregate
+  repeated TelemetryEvent events = 2;
+}

--- a/prefab.proto
+++ b/prefab.proto
@@ -335,3 +335,7 @@ message TelemetryEvents {
   string instance_hash = 1; // random UUID generated on startup - represents the server so we can aggregate
   repeated TelemetryEvent events = 2;
 }
+
+message TelemetryEventsResponse {
+
+}

--- a/prefab.proto
+++ b/prefab.proto
@@ -308,7 +308,9 @@ message ConfigEvaluationCounter {
   int64 config_id = 2;
   optional uint32 selected_index = 3; // index into the allowed-values list in the config
   ConfigValue selected_value = 4;
-  optional uint32 weighted_value_index = 5; // index into the weighted value array
+  optional uint32 config_row_index = 5;  // which row matched
+  optional uint32 conditional_value_index = 6;   // which ConditionalValue in the row matched?
+  optional uint32 weighted_value_index = 7; // index into the weighted value array
 }
 
 message ConfigEvaluationSummary {

--- a/prefab.proto
+++ b/prefab.proto
@@ -305,7 +305,7 @@ message EvaluatedConfigs {
 
 message ConfigEvaluationCounter {
   int64 count = 1;
-  int64 config_id = 2;
+  optional int64 config_id = 2;
   optional uint32 selected_index = 3; // index into the allowed-values list in the config
   optional ConfigValue selected_value = 4;
   optional uint32 config_row_index = 5;  // which row matched

--- a/prefab.proto
+++ b/prefab.proto
@@ -334,6 +334,8 @@ message ConfigEvaluationSummaries {
 message TelemetryEvent {
   oneof payload {
     ConfigEvaluationSummaries summaries = 2;
+    ExampleContexts example_contexts = 3;
+    ClientStats client_stats = 4;
   }
 }
 
@@ -343,5 +345,23 @@ message TelemetryEvents {
 }
 
 message TelemetryEventsResponse {
-
+   bool success = 1;
 }
+
+message ExampleContexts {
+  repeated ExampleContext examples = 1;
+}
+
+message ExampleContext {
+  int64 timestamp = 1;
+  ContextSet contextSet = 2;
+}
+
+
+message ClientStats {
+  int64 start = 1;
+  int64 end = 2;
+  uint64 dropped_event_count = 3;
+}
+
+

--- a/prefab.proto
+++ b/prefab.proto
@@ -307,10 +307,16 @@ message ConfigEvaluationCounter {
   int64 count = 1;
   int64 config_id = 2;
   optional uint32 selected_index = 3; // index into the allowed-values list in the config
-  ConfigValue selected_value = 4;
+  optional ConfigValue selected_value = 4;
   optional uint32 config_row_index = 5;  // which row matched
   optional uint32 conditional_value_index = 6;   // which ConditionalValue in the row matched?
   optional uint32 weighted_value_index = 7; // index into the weighted value array
+  Reason reason = 8;
+
+  enum Reason {
+    UNKNOWN = 0;
+  }
+
 }
 
 message ConfigEvaluationSummary {
@@ -322,12 +328,12 @@ message ConfigEvaluationSummary {
 message ConfigEvaluationSummaries {
   int64 start = 1;
   int64 end = 2;
-  repeated ConfigEvaluationSummaries summaries = 3;
+  repeated ConfigEvaluationSummary summaries = 3;
 }
 
 message TelemetryEvent {
   oneof payload {
-    string ConfigEvaluationSummaries = 2;
+    ConfigEvaluationSummaries summaries = 2;
   }
 }
 

--- a/prefab.proto
+++ b/prefab.proto
@@ -331,11 +331,18 @@ message ConfigEvaluationSummaries {
   repeated ConfigEvaluationSummary summaries = 3;
 }
 
+message LoggersTelemetryEvent {
+  repeated Logger loggers = 1;
+  int64 start_at = 2;
+  int64 end_at = 3;
+}
+
 message TelemetryEvent {
   oneof payload {
     ConfigEvaluationSummaries summaries = 2;
     ExampleContexts example_contexts = 3;
     ClientStats client_stats = 4;
+    LoggersTelemetryEvent loggers = 5;
   }
 }
 


### PR DESCRIPTION
This supports the collection of four kinds of data
1) Evaluation summaries (counts of config key, resulting config)
2) Example contexts
3) Client performance (dropped events)
4) Logger counts (same as existing logger stream, but can pipe through new telemetry api now)