### PR TITLE
Jd/provided

### DIFF
--- a/prefab.proto
+++ b/prefab.proto
@@ -37,11 +37,6 @@ message Provided {
 enum ProvidedSource {
   PROVIDED_SOURCE_NOT_SET = 0;
   ENV_VAR = 1;
-  // REDIS = 2;       // Store a StringList in Redis
-  // S3 = 3;          // Store a StringList in S3
-  // 1PASSWORD = 4;   // shell out to 1Password CLI
-  // YAML_URL = 5;    // fetch a StringList from a URL
-  // PREFAB_LAZY = 6; // fetch a StringList lazily from Prefab
 }
 
 message IntRange {

--- a/prefab.proto
+++ b/prefab.proto
@@ -23,7 +23,23 @@ message ConfigValue {
     LogLevel log_level = 9;
     StringList string_list = 10;
     IntRange int_range = 11;
+    Provided provided = 12;
   }
+}
+
+message Provided {
+  optional ProvidedSource source = 1;
+  optional string lookup = 2; // MY_ENV_VAR
+  optional ConfigValue value = 3; // starts null, but can be set/cached from source
+}
+enum ProvidedSource {
+  PROVIDED_SOURCE_NOT_SET = 0;
+  ENV_VAR = 1;
+  // REDIS = 2;       // Store a StringList in Redis
+  // S3 = 3;          // Store a StringList in S3
+  // 1PASSWORD = 4;   // shell out to 1Password CLI
+  // YAML_URL = 5;    // fetch a StringList from a URL
+  // PREFAB_LAZY = 6; // fetch a StringList lazily from Prefab
 }
 
 message IntRange {

--- a/prefab.proto
+++ b/prefab.proto
@@ -25,12 +25,15 @@ message ConfigValue {
     IntRange int_range = 11;
     Provided provided = 12;
   }
+  optional bool confidential = 13;   // don't log or telemetry this value
+  optional string decrypt_with = 14; // key name to decrypt with
 }
 
 message Provided {
   optional ProvidedSource source = 1;
   optional string lookup = 2; // eg MY_ENV_VAR
 }
+
 enum ProvidedSource {
   PROVIDED_SOURCE_NOT_SET = 0;
   ENV_VAR = 1;

--- a/prefab.proto
+++ b/prefab.proto
@@ -29,8 +29,7 @@ message ConfigValue {
 
 message Provided {
   optional ProvidedSource source = 1;
-  optional string lookup = 2; // MY_ENV_VAR
-  optional ConfigValue value = 3; // starts null, but can be set/cached from source
+  optional string lookup = 2; // eg MY_ENV_VAR
 }
 enum ProvidedSource {
   PROVIDED_SOURCE_NOT_SET = 0;


### PR DESCRIPTION
Add the ability to lookup a value provided in the environment.
Extensible to lookup via alternative sources in the future. 

Add the ability for a value to specify that it should be decrypted with the value of another config.

Add the ability for a value to specify that it is confidential and should not be logged or appear in telemetry.