### PR TITLE
Adds named ConfigValue

### DIFF
--- a/prefab.proto
+++ b/prefab.proto
@@ -32,6 +32,7 @@ message ConfigValue {
   optional bool confidential = 13;   // don't log or telemetry this value
   optional string decrypt_with = 14; // key name to decrypt with
   optional string name = 15; // used for naming the allowable values for feature flags
+  optional string description = 16; // used for naming the allowable values for feature flags
 }
 
 message Json {


### PR DESCRIPTION
## Description

The set of allowed values in feature flags can be unwieldy to represent in the rules UI, especially now that they can be blobs of json. Naming them will allow a more compact representation and better UX