### PR TITLE
Add ConfigType.LOG_LEVEL_V2

### DIFF
--- a/prefab.proto
+++ b/prefab.proto
@@ -95,6 +95,7 @@ enum ConfigType {
   LIMIT_DEFINITION = 5;
   DELETED = 6;
   SCHEMA = 7;
+  LOG_LEVEL_V2 = 8;
 }
 
 message Config {
@@ -123,7 +124,6 @@ message Config {
     INT_RANGE = 11;
     DURATION = 12;
     JSON = 13;
-    LOG_LEVEL_V2 = 14;
   }
 }
 


### PR DESCRIPTION
## Description 

This corrects #32 by Adding ConfigType.LOG_LEVEL_V2 and removing Value type LOG_LEVEL_V2


## Testing

none required